### PR TITLE
fix(image validation): pass through parameters to the upper validation method

### DIFF
--- a/src/Validators/Base64Validator.php
+++ b/src/Validators/Base64Validator.php
@@ -96,7 +96,7 @@ class Base64Validator
     public function validateBase64Image(string $attribute, $value, array $parameters, Validator $validator): bool
     {
         return !empty($value)
-            ? $validator->validateImage($attribute, $this->convertToFile($value))
+            ? $validator->validateImage($attribute, $this->convertToFile($value), $parameters)
             : true;
     }
 


### PR DESCRIPTION
Hi @crazybooot, I wanted to offer this change that makes your package (again) fully compatible with Laravel 12.

This PR fixes an issue with the image validation. Laravel 12 introduced a new parameter to the image validation function which enabled checking SVG files, which is now disabled by default. Without handing over these parameters to the base-image validation method, your implementation is no longer compatible to this change.

Reference: https://laravel.com/docs/12.x/upgrade#image-validation